### PR TITLE
refactor(Auth, ErrorMapper)

### DIFF
--- a/lib/core/exceptions/error_mapper.dart
+++ b/lib/core/exceptions/error_mapper.dart
@@ -18,6 +18,10 @@ class ErrorMapper {
 
   static ErrorState _mapAuthError(FirebaseAuthException error) {
     switch (error.code) {
+      case 'invalid-credential':
+        return const InvalidCredentials(
+          "Las credenciales que ingresó son incorrectas",
+        );
       case 'invalid-email':
         return const InvalidCredentials("Correo inválido.");
       case 'email-already-in-use':

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,4 +9,3 @@ void main() async {
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   runApp(const ProviderScope(child: Serviexpress()));
 }
-

--- a/lib/presentation/pages/auth_page.dart
+++ b/lib/presentation/pages/auth_page.dart
@@ -34,6 +34,31 @@ class _AuthScreenState extends ConsumerState<AuthPage> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<ResultState>(authViewModelProvider, (previous, next) {
+      switch (next) {
+        case Idle():
+          LoadingScreen.hide();
+          break;
+        case Loading():
+          LoadingScreen.show(context);
+          break;
+        case Success():
+          LoadingScreen.hide();
+          if (mounted) {
+            Navigator.push(
+              context,
+              PageRouteBuilder(pageBuilder: (c, a, s) => const Verification()),
+            );
+          }
+          break;
+        case Failure(:final error):
+          LoadingScreen.hide();
+          if (mounted) {
+            Alerts.instance.showErrorAlert(context, error.message);
+          }
+          break;
+      }
+    });
     return Scaffold(
       resizeToAvoidBottomInset: true,
       body: Container(
@@ -219,40 +244,10 @@ class _AuthScreenState extends ConsumerState<AuthPage> {
                       );
                       return;
                     }
-                    LoadingScreen.show(context);
+
                     await ref
                         .read(authViewModelProvider.notifier)
                         .loginUser(email, password);
-
-                    final result = ref.read(authViewModelProvider);
-
-                    switch (result) {
-                      case Idle():
-                        LoadingScreen.hide();
-                      case Loading():
-                      case Success():
-                        LoadingScreen.hide();
-
-                        if (mounted) {
-                          Navigator.push(
-                            context,
-                            PageRouteBuilder(
-                              pageBuilder: (c, a, s) => const Verification(),
-                            ),
-                          );
-                        }
-
-                        break;
-                      case Failure(:final error):
-                        LoadingScreen.hide();
-                        if (mounted) {
-                          Alerts.instance.showErrorAlert(
-                            context,
-                            error.message,
-                          );
-                        }
-                        break;
-                    }
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: AppColor.btnColor,


### PR DESCRIPTION
Se implementó una escucha reactiva del estado `ResultState` dentro del método build del widget, utilizando `ref.listen` para actualizar la interfaz de usuario en función del estado actual de autenticación.

- En estado Idle, se oculta la pantalla de carga.
- En estado Loading, se muestra una pantalla de carga modal.
- En estado Success, se oculta la pantalla de carga y se navega a la pantalla de verificación.
- En estado Failure, se oculta la pantalla de carga y se despliega una alerta con el mensaje de error recibido.

Además, se mejoró el manejo del botón de inicio de sesión usando `ref.read` para invocar el método de login, incluyendo validaciones para campos vacíos y mostrando alertas correspondientes.

Finalmente, se agregaron mapeos específicos para códigos de error de FirebaseAuth, mejorando el feedback de errores para el usuario.