### PR TITLE
Reglas para no ofuzcar clases necesarias

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -46,10 +46,10 @@ android {
 
     signingConfigs {
         create("release") {
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
-            storeFile = keystoreProperties["storeFile"]?.let { file(it) }
-            storePassword = keystoreProperties["storePassword"] as String
+            keyAlias = keystoreProperties.getProperty("keyAlias") ?: ""
+            keyPassword = keystoreProperties.getProperty("keyPassword") ?: ""
+            storeFile = keystoreProperties.getProperty("storeFile")?.let { file(it) }
+            storePassword = keystoreProperties.getProperty("storePassword") ?: ""
         }
     }
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -39,3 +39,7 @@
 }
 -keepattributes RuntimeVisibleAnnotations
 -keepattributes AnnotationDefault
+
+# PLAY CORE
+-keep class com.google.android.play.** { *; }
+-dontwarn com.google.android.play.**


### PR DESCRIPTION
Se agregaron reglas ProGuard para que R8 no ofuzque clases necesarias de Play Core